### PR TITLE
feat: Added watch commands for tasks and results

### DIFF
--- a/docs/armonik_core.rst
+++ b/docs/armonik_core.rst
@@ -1,19 +1,84 @@
 ArmoniK.CLI Core
 ======================
 
-This is arguable one of the main things you'll be interacting with when working on ArmoniK.CLI.
+This is arguably one of the main components you'll interact with when working on ArmoniK.CLI.
 
-We'll give an overview of the various custom decorators, parameter types and objects that are provided. 
-
+We'll give an overview of the various custom decorators, parameter types, objects, and convenience functions that are provided.
 
 Serialization of ArmoniK types
 ------------------------------
 
-When working with ArmoniK you'll be dealing with a lot of its objects/entity types (Task, Session, etc.). 
-To assist with that, ArmoniK.CLI's core module provides a function :code:`serialize`. Said function converts 
-not just ArmoniK objects but also general Python objects into a JSON-serializable structure. This allows you to, for example
-pass in a list of Tasks to get a list of serialized tasks. There are however certain requirements/limitations that 
-you must handle yourself. Dict keys must be strings or else the serialize function will fail with an :code:`ArmoniKCLIError`.
+When working with ArmoniK you'll be dealing with many of its objects or entity types (Task, Session, etc.). 
+To assist with that, ArmoniK.CLI's core module provides a function :code:`serialize`. This function converts 
+not just ArmoniK objects but also general Python objects into a JSON-serializable structure. This allows you to, for example,
+pass in a list of Tasks to get back a list of serialized tasks.
 
-For more information about usage, we recommend you look at said function's documentation at :doc:`CLI Reference <./cli_reference>` or 
-at the unit tests for the serializer. 
+.. note::
+   There are certain requirements/limitations you must handle yourself:
+   
+   * Dictionary keys must be strings or the :code:`serialize` function will raise :code:`ArmoniKCLIError`.
+   * Complex or custom Python objects that do not reduce easily to JSON primitives (strings, numbers, booleans, lists, dictionaries) may require additional handling.
+
+For more information about usage, we recommend you look at the :code:`serialize` function's documentation in the 
+:doc:`CLI Reference <./cli_reference>` or review the unit tests for the serializer.
+
+Cross-Platform Input Handling
+-----------------------------
+
+In addition to serialization tools, ArmoniK.CLI provides a small helper utility for reading single key presses 
+in a cross-platform way. This is especially useful for interactive CLI scenarios, menu navigation, or prompting 
+the user for a quick key press without requiring the Enter key. This is used for instance in the :mod:`watch` commands
+
+The core function is called :code:`get_key`, implemented differently for Windows and non-Windows systems:
+
+- **Windows**: Uses the :mod:`msvcrt` module to read a single character. Special sequences (like arrow keys) 
+  are detected by reading two consecutive characters.
+- **Non-Windows (Unix-like)**: Uses :mod:`termios`, :mod:`tty`, and :mod:`select` to read from stdin in a 
+  non-blocking (or blocking) manner.
+
+Usage
+^^^^^
+
+Here are a few examples of how to use :code:`get_key`:
+
+.. code-block:: python
+
+   # Example 1: Blocking call on any platform
+   print("Press any key...")
+   key = get_key(blocking=True)
+   print(f"You pressed: {key}")
+
+   # Example 2: Non-blocking call (Windows only example)
+   # On non-Windows, you can still pass blocking=False, but remember to handle the timeouts.
+   key = get_key(blocking=False, timeout=0.5)
+   if key:
+       print(f"You pressed: {key}")
+   else:
+       print("No key pressed within 0.5 seconds")
+
+   # Example 3: Handling Ctrl+C gracefully
+   try:
+       key = get_key(blocking=True, catch=True)
+       if key == "\x03":
+           print("Detected Ctrl+C!")
+   except KeyboardInterrupt:
+       # If catch=False, a normal KeyboardInterrupt could occur
+       print("KeyboardInterrupt raised!")
+
+When a recognized special key (like an arrow key) is pressed, :code:`get_key` will return strings such as 
+:code:`"UP"`, :code:`"DOWN"`, :code:`"LEFT"`, :code:`"RIGHT"`, or :code:`"ESCAPE"` in the case of an Escape press. 
+Otherwise, it attempts to return the literal character pressed.
+
+.. note::
+   * Windows uses :mod:`msvcrt` to determine if a key was pressed (:code:`msvcrt.kbhit()`) and then reads 
+     with :code:`msvcrt.getch()`.
+   * On Unix-like systems, raw mode is used temporarily to capture the keys without requiring the Enter key. 
+     The :mod:`select` call is used for optional timeouts.
+   * This is meant as a simple utility, it exists because Rich's LiveDisplay doesn't work well with other libraries like (curses, pynput, etc.); 
+     for more complex needs where Rich's LiveDisplay isn't present you may consider more specialized libraries.
+
+----
+
+That covers the core utilities around serialization and cross-platform input handling in ArmoniK.CLI. 
+For additional usage examples, advanced patterns, or potential edge cases, refer to the unit tests or to the 
+:doc:`CLI Reference <./cli_reference>`.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,7 +36,7 @@ For instance, say we want to get all of the tasks associated with a specific ses
 
 .. code-block:: console 
 
-    $ armonik task list -e 170.10.10.122:5001 --filter "session_id="1085c427-89da-4104-aa32-bc6d3d84d2b2'" --output table   
+    $ armonik task list -e 170.10.10.122:5001 --filter "session_id='1085c427-89da-4104-aa32-bc6d3d84d2b2'" --output table   
 
 or if we want to list all of the tasks within a specific session that have error'd out we can do 
 

--- a/src/armonik_cli/commands/__init__.py
+++ b/src/armonik_cli/commands/__init__.py
@@ -4,5 +4,4 @@ from .partitions import partitions
 from .results import results
 from .cluster import cluster
 
-
 __all__ = ["sessions", "tasks", "partitions", "results", "cluster"]

--- a/src/armonik_cli/commands/results.py
+++ b/src/armonik_cli/commands/results.py
@@ -2,16 +2,36 @@ from collections import defaultdict
 import grpc
 import rich_click as click
 
-from typing import IO, List, Union
+from typing import IO, List, Optional, Union
 
-from armonik.client.results import ArmoniKResults
-from armonik.common import Result, Direction
-from armonik.common.filter import PartitionFilter, Filter
+from armonik.client import ArmoniKResults
+from armonik.common import (
+    Result,
+    Direction,
+    EventTypes,
+    NewResultEvent,
+    ResultStatusUpdateEvent,
+    ResultStatus,
+)
+from armonik.common.filter import ResultFilter, Filter
 
+from armonik_cli.commands.watch import (
+    Watch,
+    WatchDisplay,
+    WatchGroup,
+    WatchGroupDisplay,
+    create_nonblocking_event_handler,
+)
 from armonik_cli.core import console, base_command, base_group
+from armonik_cli.core.common import calculate_duration, format_timestamp
 from armonik_cli.core.options import MutuallyExclusiveOption
 from armonik_cli.core.params import FieldParam, FilterParam, ResultNameDataParam
 
+from rich.live import Live
+from rich.panel import Panel
+from rich.text import Text
+from rich.table import Table
+from rich.layout import Layout
 
 RESULT_TABLE_COLS = [
     ("Name", "Name"),
@@ -59,7 +79,7 @@ def results() -> None:
 def result_list(
     endpoint: str,
     output: str,
-    filter_with: Union[PartitionFilter, None],
+    filter_with: Union[ResultFilter, None],
     sort_by: Filter,
     sort_direction: str,
     page: int,
@@ -234,3 +254,323 @@ def result_delete_data(
                 session_result_mapping[result.session_id].append(result_id)
         for session_id, result_ids_for_session in session_result_mapping.items():
             results_client.delete_result_data(result_ids_for_session, session_id)
+
+
+class ResultWatch(Watch[Result, ResultStatus]):
+    """Watches and tracks the status of a single ArmoniK `Result`.
+
+    This class wraps around a `Result` object, observing status changes and
+    maintaining a status history (via its `status_tracker`).
+    """
+
+    status_cls = ResultStatus
+
+    def refresh(self, client: ArmoniKResults):
+        """Refresh the data of this result via a gRPC call.
+
+        Uses the provided client to retrieve the latest `Result` object and
+        updates the internal data and current status accordingly.
+
+        Args:
+            client (ArmoniKResults): An ArmoniKResults client.
+        """
+        self.data = client.get_result(self.id)
+        self._current_status = ResultStatus(self.data.status).name
+
+
+class ResultsWatchGroup(WatchGroup[ResultFilter]):
+    """Watches and monitors multiple ArmoniK results, displaying live updates.
+
+    This group manages multiple `ResultWatch` instances and registers event handlers
+    for real-time monitoring of result statuses.
+    """
+
+    def _init_populate_watches(self):
+        """Populate the watch dictionary with `ResultWatch` objects.
+
+        1. Initializes the `results_client` using the gRPC channel.
+        2. If `entity_ids` are provided:
+            - Creates a `ResultWatch` for each specified ID and refreshes it immediately.
+        3. Otherwise, lists results from the server using the given filter or session ID:
+            - If no results are returned and the session ID is still unknown, prompt the user to enter one.
+            - For each returned result, creates a corresponding `ResultWatch` and sets its data.
+
+        Raises:
+            Prompt: If no results are found and no session ID is available,
+                prompts the user to supply a session ID in the terminal.
+        """
+        self.results_client = ArmoniKResults(self.grpc_channel)
+        if self.entity_ids:
+            for result_id in self.entity_ids:
+                self.watches[result_id] = ResultWatch(result_id)
+                self.watches[result_id].refresh(self.results_client)
+        else:
+            watchable_results_count, watchable_results = self.results_client.list_results(
+                result_filter=self.filter_with,
+                page=0,
+                page_size=self.limit,
+                sort_field=Result.created_at if self.sort_by is None else self.sort_by,
+                sort_direction=Direction.ASC
+                if self.sort_direction.capitalize() == "ASC"
+                else Direction.DESC,
+            )
+            # (most likely) No session id was provided in the filter nor passed along, so we ask for it again
+            if watchable_results_count == 0 and not self.session_id:
+                self.session_id = click.prompt(
+                    "No results available to watch, you can however specify a session and results that satisfy said filter within session will be watched automatically"
+                )
+            for result in watchable_results:
+                self.watches[result.result_id] = ResultWatch(result.result_id)
+                self.watches[result.result_id].data = result
+
+    def _register_event_handlers(self):
+        """Register event handlers for result status updates and new results.
+
+        Spawns one or more background threads via `create_nonblocking_event_handler` to:
+          - Listen for `RESULT_STATUS_UPDATE` events and call `update_watch_status`.
+          - If a filter is provided, also listen for `NEW_RESULT` events to automatically
+            add newly created results to the watch group.
+        """
+        self.status_update_handler = create_nonblocking_event_handler(
+            self.grpc_channel,
+            self.session_id,
+            [EventTypes.RESULT_STATUS_UPDATE],
+            [self.update_watch_status],
+        )
+        self.status_update_handler.start()
+        if (
+            self.filter_with is not None
+        ):  # NOTE: This doesn't work well for results since they're all created at the start, instead maybe look into some sort of scheduled polling until we fill?
+            self.autofill_handler = create_nonblocking_event_handler(
+                self.grpc_channel,
+                self.session_id,
+                [EventTypes.NEW_RESULT],
+                [self.autofill],
+                result_filter=self.filter_with,
+            )
+            self.autofill_handler.start()
+
+    def update_watch_status(
+        self, session_id: str, event_type: EventTypes, event: ResultStatusUpdateEvent
+    ) -> bool:
+        """Update the status of a result upon receiving a `RESULT_STATUS_UPDATE` event.
+
+        If the reported `result_id` is already being watched, its current status
+        is updated to match the new status from the event.
+
+        Args:
+            session_id (str): The session ID for which the event applies.
+            event_type (EventTypes): The type of the event (must be `RESULT_STATUS_UPDATE`).
+            event (ResultStatusUpdateEvent): The event data containing the updated status.
+
+        Returns:
+            bool: Always returns False, allowing the event listener to keep running.
+        """
+        if event_type == EventTypes.RESULT_STATUS_UPDATE and event.result_id in self.watches:
+            self.watches[event.result_id].current_status = ResultStatus(event.status).name
+        return False
+
+    def autofill(self, session_id: str, event_type: EventTypes, event: NewResultEvent) -> bool:
+        """Callback for handling new results events to fill up the watches if we're under the limit.
+
+        Args:
+            session_id (str): The session ID associated with the event.
+            event_type (EventTypes): The type of the event.
+            event (NewResultEvent): The event data containing the new result information.
+
+        Returns:
+            bool: Always returns False to not close the session.
+        """
+        if len(list(self.watches.keys())) < self.limit and event_type == EventTypes.NEW_RESULT:
+            self.watches[event.result_id] = ResultWatch(event.result_id)
+            self.watches[event.result_id].refresh(self.results_client)
+        return False
+
+
+class ResultWatchDisplay(WatchDisplay):
+    def _create_metadata_display(self):
+        """Create a display panel for the results metadata.
+
+        Returns:
+            Panel: A Rich Panel containing results metadata.
+        """
+        metadata_table = Table(title="Results metadata", show_header=False, border_style="yellow")
+
+        metadata_table.add_column("Label", style="cyan")
+        metadata_table.add_column("Value")
+
+        if self.watch.data:
+            metadata_table.add_row(
+                "[bold]Name[/bold]",
+                self.watch.data.name,
+            )
+            metadata_table.add_row(
+                "[bold]Session ID[/bold]",
+                f"[link=http://{self.endpoint}/admin/en/tasks?0-root-1-0={self.watch.data.session_id}]{self.watch.data.session_id}[/link]"
+                if self.endpoint
+                else self.watch.data.session_id,
+            )
+            metadata_table.add_row(
+                "Owner Task ID",
+                f"[link=http://{self.endpoint}/admin/en/tasks?0-root-1-0={self.watch.data.owner_task_id}]{self.watch.data.session_id}[/link]"
+                if self.endpoint
+                else self.watch.data.owner_task_id,
+            )
+            metadata_table.add_row("Created By", self.watch.data.created_by)
+            metadata_table.add_row(
+                "Size",
+                str(self.watch.data.size),
+            )
+        else:
+            metadata_table.add_row("Data not yet retrieved")
+
+        metadata_panel = Panel(metadata_table)
+        return metadata_panel
+
+    def _create_status_display(self):
+        """Create a display panel for the results status.
+
+        Returns:
+            Panel: A Rich Panel containing results status.
+        """
+        table = Table(
+            title=f"[bold]Result ID:[/bold] [link=http://{self.endpoint}/admin/en/results/{self.watch.id}]{self.watch.id}[/link]"
+            if self.endpoint
+            else self.watch.id,
+            show_header=True,
+            header_style="bold magenta",
+            border_style="blue",
+        )
+
+        table.add_column("Status", style="cyan")
+        table.add_column("Start Time", style="green")
+        table.add_column("Duration", style="yellow")
+
+        table_rows = []
+        for status, entries in self.watch.status_tracker.items():
+            if entries:  # Only show statuses that have occurred
+                for entry in entries:
+                    table_rows.append(
+                        (
+                            status,
+                            format_timestamp(entry["start"]),
+                            str(calculate_duration(entry["start"], entry["end"])),
+                        )
+                    )
+
+        for status, start, dur in sorted(table_rows, key=lambda v: v[1]):
+            table.add_row(status, start, dur)
+        table.expand = True
+        return Panel(table, title="Live Status Tracking", border_style="green")
+
+
+class ResultsWatchGroupDisplay(WatchGroupDisplay):
+    """Class for displaying information about monitored results"""
+
+    def display(self):
+        """Assemble the full layout for the live display.
+
+        Returns:
+            Layout: A Rich Layout object combining the navigation bar, status history,
+            and task metadata panels.
+        """
+        nav_bar = Layout(self.create_navigation_bar(), name="nav")
+        nav_bar.size = 2
+        help_bar = Layout(self.create_help_bar(), name="help")
+        help_bar.size = 1
+        full_layout = Layout()
+        if self.watches:
+            watch_display = ResultWatchDisplay(
+                self.watches[self.current_tab], self.endpoint
+            ).display()
+        else:
+            watch_display = Panel(Text("Nothing to watch.."))
+        full_layout.split_column(nav_bar, Layout(watch_display, name="content"), help_bar)
+        return full_layout
+
+
+@results.command("watch")
+@click.option(
+    "--id",
+    "result_ids",
+    cls=MutuallyExclusiveOption,
+    mutual=["filter_with"],
+    require_one=True,
+    type=str,
+    default=[],
+    multiple=True,
+    metavar="RESULT_IDS",
+)
+@click.option(
+    "-f",
+    "--filter",
+    "filter_with",
+    type=FilterParam("Result"),
+    cls=MutuallyExclusiveOption,
+    mutual=["result_ids"],
+    require_one=True,
+    required=False,
+    help="An expression to filter for results to watch with.",
+    metavar="FILTER EXPR",
+)
+@click.option(
+    "--limit",
+    cls=MutuallyExclusiveOption,
+    mutual=["result_ids"],
+    type=int,
+    required=False,
+    default=1,
+    help="The maximum number of results to retrieve when using a filter.",
+)
+@click.option(
+    "--session-id",
+    type=str,
+    required=False,
+    help="Id of the session to look for the result in if none were specified in the filter",
+    metavar="SESSION_ID",
+)
+@click.option(
+    "--sort-by",
+    type=FieldParam("Result"),
+    required=False,
+    help="Attribute of results to sort with.",
+)
+@click.option(
+    "--sort-direction",
+    type=click.Choice(["asc", "desc"], case_sensitive=False),
+    default="asc",
+    required=False,
+    help="Whether to sort by ascending or by descending order.",
+)
+@base_command
+def results_watch(
+    endpoint: str,
+    output: str,
+    filter_with: Optional[ResultFilter],
+    result_ids: List[str],
+    limit: int,
+    session_id: Optional[str],
+    sort_by,
+    sort_direction,
+    debug: bool,
+) -> None:
+    """Start a watch session to get a live overview of results in your cluster."""
+    # The ResultsWatchGroup creates watches for us and spawns threads to update the different watches
+    result_watchers = ResultsWatchGroup(
+        endpoint=endpoint,
+        debug=debug,
+        filter_with=filter_with,
+        session_id=session_id,
+        limit=limit,
+        entity_ids=result_ids,
+        sort_by=sort_by,
+        sort_direction=sort_direction,
+    )
+    result_display = ResultsWatchGroupDisplay(result_watchers.get_watches_view(), endpoint)
+    # open file and dump print(f"Channel state <{time.time()}>: {self.grpc_channel.get_state()}") onto it
+    with Live(result_display.display(), refresh_per_second=10, screen=True) as live:
+        while True:
+            result_display.update()
+            result_display.update_contents(result_watchers.get_watches_view())
+            live.update(result_display.display())
+    pass

--- a/src/armonik_cli/commands/tasks.py
+++ b/src/armonik_cli/commands/tasks.py
@@ -2,14 +2,34 @@ import grpc
 import rich_click as click
 
 from datetime import timedelta
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional
 
-from armonik.client.tasks import ArmoniKTasks
-from armonik.common import Task, TaskDefinition, TaskOptions, Direction
-from armonik.common.filter import TaskFilter, Filter
+from armonik.client import ArmoniKTasks
+from armonik.common import Task, TaskStatus, TaskDefinition, TaskOptions, Direction, Filter
+from armonik.common.filter import TaskFilter
 
+from armonik_cli.commands.watch import (
+    Watch,
+    WatchDisplay,
+    WatchGroup,
+    WatchGroupDisplay,
+    create_nonblocking_event_handler,
+)
+from armonik_cli.core.common import format_timestamp, calculate_duration
 from armonik_cli.core import console, base_command, base_group
+from armonik_cli.core.options import MutuallyExclusiveOption
 from armonik_cli.core.params import KeyValuePairParam, TimeDeltaParam, FilterParam, FieldParam
+from armonik.client.events import (
+    EventTypes,
+    TaskStatusUpdateEvent,
+    NewTaskEvent,
+)
+
+from rich.live import Live
+from rich.panel import Panel
+from rich.text import Text
+from rich.table import Table
+from rich.layout import Layout
 
 TASKS_TABLE_COLS = [("ID", "Id"), ("Status", "Status"), ("CreatedAt", "CreatedAt")]
 
@@ -248,3 +268,327 @@ def tasks_create(
             print_format=output,
             table_cols=TASKS_TABLE_COLS,
         )
+
+
+class TaskWatch(Watch[Task, TaskStatus]):
+    """Class that tracks the status and data of a Task"""
+
+    status_cls = TaskStatus
+
+    def refresh(self, client):
+        """Refreshes the data of the watched task via a gRPC call."""
+        self.data.refresh(client)
+        self.current_status = TaskStatus(
+            self.data.status
+        ).name  # If things go haywire it's probably this
+
+
+class TasksWatchGroup(WatchGroup[TaskFilter]):
+    """Class for monitoring ArmoniK results and displaying live updates"""
+
+    def _init_populate_watches(self):
+        """Populate the watch dictionary with TaskWatch objects.
+
+        1. Creates a `tasks_client` using the gRPC channel.
+        2. If `self.entity_ids` is set, creates a `TaskWatch` for each entity ID and refreshes it.
+        3. Otherwise, lists tasks from the server (using any existing filter criteria):
+           - If no tasks are found and no session ID is known, prompts the user for a session ID.
+           - For each listed task, creates a `TaskWatch` and stores its data.
+
+        Raises:
+            Prompt if no tasks are available and no session ID was provided.
+        """
+        self.tasks_client = ArmoniKTasks(self.grpc_channel)
+        if self.entity_ids:
+            for task_id in self.entity_ids:
+                self.watches[task_id] = TaskWatch(task_id)
+                self.watches[task_id].refresh(self.tasks_client)
+        else:
+            watchable_tasks_count, watchable_tasks = self.tasks_client.list_tasks(
+                task_filter=self.filter_with,
+                page=0,
+                page_size=self.limit,
+                sort_field=Task.created_at if self.sort_by is None else self.sort_by,
+                sort_direction=Direction.ASC
+                if self.sort_direction.capitalize() == "ASC"
+                else Direction.DESC,
+            )
+            # (most likely) No session id was provided in the filter nor passed along, so we ask for it again
+            if watchable_tasks_count == 0 and not self.session_id:
+                self.session_id = click.prompt(
+                    "No taskss available to watch, you can however specify a session and tasks that satisfy said filter within session will be watched automatically"
+                )
+            for task in watchable_tasks:
+                self.watches[task.id] = TaskWatch(task.id)
+                self.watches[task.id].data = task
+
+    def _register_event_handlers(self):
+        """Register event handlers for task updates and data refresh.
+
+        This method spawns background threads (via `create_nonblocking_event_handler`) to listen
+        for specific event types (e.g., TASK_STATUS_UPDATE) and routes them to the appropriate
+        callback methods (`update_watch_status` or `refresh_task_data`). If a filter is present,
+        it also registers an additional handler to automatically watch newly created tasks satisfying
+        sait filter (NEW_TASK events).
+        """
+        self.status_update_handler = create_nonblocking_event_handler(
+            self.grpc_channel,
+            self.session_id,
+            [EventTypes.TASK_STATUS_UPDATE],
+            [self.update_watch_status],
+        )
+        self.task_data_refresh_handler = create_nonblocking_event_handler(
+            self.grpc_channel,
+            self.session_id,
+            [EventTypes.TASK_STATUS_UPDATE],
+            [self.refresh_task_data],
+        )
+        self.status_update_handler.start()
+        self.task_data_refresh_handler.start()
+        if (
+            self.filter_with is not None
+        ):  # NOTE: I think this doesn't work well for results since they're all created at the start, instead maybe look into some sort of scheduled polling until we fill?
+            self.autofill_handler = create_nonblocking_event_handler(
+                self.grpc_channel,
+                self.session_id,
+                [EventTypes.NEW_TASK],
+                [self.autofill],
+                task_filter=self.filter_with,
+            )
+            self.autofill_handler.start()
+
+    def update_watch_status(
+        self, session_id: str, event_type: EventTypes, event: TaskStatusUpdateEvent
+    ) -> bool:
+        """Update the status of a task when receiving a TASK_STATUS_UPDATE event.
+
+        Args:
+            session_id (str): The ID of the session for which the event applies.
+            event_type (EventTypes): The type of the event (e.g., TASK_STATUS_UPDATE).
+            event (TaskStatusUpdateEvent): The event data containing the updated task status.
+
+        Returns:
+            bool: Always returns False, indicating the event listener should continue running.
+        """
+        if event_type == EventTypes.TASK_STATUS_UPDATE and event.task_id in self.watches:
+            self.watches[event.task_id].current_status = TaskStatus(event.status).name
+        return False
+
+    def refresh_task_data(
+        self, session_id: str, event_type: EventTypes, event: TaskStatusUpdateEvent
+    ) -> bool:
+        """Refresh task data upon a TASK_STATUS_UPDATE event.
+
+        When a task status changes, this callback triggers a refresh of the task’s
+        data via the gRPC client. This ensures that the local watch’s task metadata is always
+        up to date.
+
+        Args:
+            session_id (str): The ID of the session for which the event applies.
+            event_type (EventTypes): The type of the event (typically TASK_STATUS_UPDATE).
+            event (TaskStatusUpdateEvent): The event data containing the task ID.
+
+        Returns:
+            bool: Always returns False, indicating the event listener should continue running.
+        """
+        if event_type == EventTypes.TASK_STATUS_UPDATE and event.task_id in self.watches:
+            self.watches[event.task_id].refresh(self.tasks_client)
+        return False
+
+    def autofill(self, session_id: str, event_type: EventTypes, event: NewTaskEvent) -> bool:
+        """Callback for handling new results events to fill up the watches if we're under the limit.
+
+        Args:
+            session_id (str): The session ID associated with the event.
+            event_type (EventTypes): The type of the event.
+            event (NewTaskEvent): The event data containing the new task information.
+
+        Returns:
+            bool: Always returns False to not close the session.
+        """
+        if len(list(self.watches.keys())) < self.limit and event_type == EventTypes.NEW_TASK:
+            self.watches[event.task_id] = TaskWatch(event.id)
+            self.watches[event.task_id].refresh(self.tasks_client)
+        return False
+
+
+class TaskWatchDisplay(WatchDisplay):
+    def _create_metadata_display(self):  # DOWN
+        """Create a display panel for the tasks metadata.
+
+        Returns:
+            Panel: A Rich Panel containing tasks metadata.
+        """
+        metadata_table = Table(title="Task metadata", show_header=False, border_style="yellow")
+
+        metadata_table.add_column("Label", style="cyan")
+        metadata_table.add_column("Value")
+
+        if self.watch.data:
+            metadata_table.add_row(
+                "[bold]Session ID[/bold]",
+                f"[link=http://{self.endpoint}/admin/en/tasks?0-root-1-0={self.watch.data.session_id}]{self.watch.data.session_id}[/link]"
+                if self.endpoint
+                else self.watch.data.session_id,
+            )
+            metadata_table.add_row(
+                "Owner Pod Id",
+                f"[link=http://{self.endpoint}/seq/#/events?range=1d&filter=ownerPodId%20%3D%20'{self.watch.data.owner_pod_id}']{self.watch.data.owner_pod_id}[/link]",
+            )
+            metadata_table.add_row("Pod Hostname", self.watch.data.pod_hostname)
+            metadata_table.add_row(
+                "Data dependencies", str(self.watch.data.count_data_dependencies)
+            )
+            metadata_table.add_row("Outputs", str(self.watch.data.count_expected_output_ids))
+            metadata_table.add_row("Status Message", self.watch.data.status_message)
+        else:
+            metadata_table.add_row("Data not yet retrieved")
+
+        metadata_panel = Panel(metadata_table)
+        return metadata_panel
+
+    def _create_status_display(self):  # DOWN
+        """Create a display panel for the results status.
+
+        Returns:
+            Panel: A Rich Panel containing results status.
+        """
+        table = Table(
+            title=f"[bold]Task ID:[/bold] [link=http://{self.endpoint}/admin/en/tasks/{self.watch.id}]{self.watch.id}[/link]"
+            if self.endpoint
+            else self.watch.id,
+            show_header=True,
+            header_style="bold magenta",
+            border_style="blue",
+        )
+
+        table.add_column("Status", style="cyan")
+        table.add_column("Start Time", style="green")
+        table.add_column("Duration", style="yellow")
+
+        table_rows = []
+        for status, entries in self.watch.status_tracker.items():
+            if entries:  # Only show statuses that have occurred
+                for entry in entries:
+                    table_rows.append(
+                        (
+                            status,
+                            format_timestamp(entry["start"]),
+                            str(calculate_duration(entry["start"], entry["end"])),
+                        )
+                    )
+
+        for status, start, dur in sorted(table_rows, key=lambda v: v[1]):
+            table.add_row(status, start, dur)
+        table.expand = True
+        return Panel(table, title="Live Status Tracking", border_style="green")
+
+
+class TasksWatchGroupDisplay(WatchGroupDisplay):
+    """Class for displaying information about monitored tasks"""
+
+    def display(self):  # DOWN
+        """Assemble the full layout for the live display.
+
+        Returns:
+            Layout: A Rich Layout object combining the navigation bar, status history,
+            and task metadata panels.
+        """
+        nav_bar = Layout(self.create_navigation_bar(), name="nav")
+        nav_bar.size = 2
+        help_bar = Layout(self.create_help_bar(), name="help")
+        help_bar.size = 1
+        full_layout = Layout()
+        if self.watches:
+            watch_display = TaskWatchDisplay(
+                self.watches[self.current_tab], self.endpoint
+            ).display()
+        else:
+            watch_display = Panel(Text("Nothing to watch.."))
+        full_layout.split_column(nav_bar, Layout(watch_display, name="content"), help_bar)
+        return full_layout
+
+
+@tasks.command("watch")
+@click.option(
+    "--id",
+    "task_ids",
+    cls=MutuallyExclusiveOption,
+    mutual=["filter_with"],
+    require_one=True,
+    type=str,
+    default=[],
+    multiple=True,
+)
+@click.option(
+    "-f",
+    "--filter",
+    "filter_with",
+    type=FilterParam("Task"),
+    cls=MutuallyExclusiveOption,
+    mutual=["task_ids"],
+    require_one=True,
+    required=False,
+    help="An expression to filter for tasks to watch with.",
+    metavar="FILTER EXPR",
+)
+@click.option(
+    "--limit",
+    cls=MutuallyExclusiveOption,
+    mutual=["task_ids"],
+    type=int,
+    required=False,
+    default=1,
+    help="The maximum number of tasks to retrieve when using a filter.",
+)
+@click.option(
+    "--session-id",
+    type=str,
+    required=False,
+    help="Id of the session to look for the task in if none were specified in the filter",
+    metavar="SESSION_ID",
+)
+@click.option(
+    "--sort-by",
+    type=FieldParam("Task"),
+    required=False,
+    help="Attribute of tasks to sort with, this defaults to the sorting for the most recently created tasks.",
+)
+@click.option(
+    "--sort-direction",
+    type=click.Choice(["asc", "desc"], case_sensitive=False),
+    default="asc",
+    required=False,
+    help="Whether to sort by ascending or by descending order.",
+)
+@base_command
+def tasks_watch(
+    endpoint: str,
+    output: str,
+    filter_with: Optional[TaskFilter],
+    task_ids: List[str],
+    limit: int,
+    session_id: Optional[str],
+    sort_by,
+    sort_direction,
+    debug: bool,
+) -> None:
+    """Start a watch session to get a live overview of tasks in your cluster."""
+    # The TasksWatchGroup creates watches for us and spawns threads to update the different watches
+    tasks_watchers = TasksWatchGroup(
+        endpoint=endpoint,
+        debug=debug,
+        filter_with=filter_with,
+        session_id=session_id,
+        limit=limit,
+        entity_ids=task_ids,
+        sort_by=sort_by,
+        sort_direction=sort_direction,
+    )
+    tasks_display = TasksWatchGroupDisplay(tasks_watchers.get_watches_view(), endpoint)
+    with Live(tasks_display.display(), refresh_per_second=10, screen=True) as live:
+        while True:
+            tasks_display.update()
+            tasks_display.update_contents(tasks_watchers.get_watches_view())
+            live.update(tasks_display.display())
+    pass

--- a/src/armonik_cli/commands/watch.py
+++ b/src/armonik_cli/commands/watch.py
@@ -1,0 +1,277 @@
+from enum import IntEnum
+from queue import Queue
+from threading import Thread
+import time
+
+from typing import Callable, Dict, List, Optional, Generic, Type, TypeVar
+
+import grpc
+from armonik_cli.core.input import get_key
+import rich_click as click
+
+from rich.text import Text
+from rich.layout import Layout
+from rich.columns import Columns
+from rich.style import Style
+from armonik.common import Filter
+from armonik.common.filter import TaskFilter, ResultFilter
+from armonik.client.events import ArmoniKEvents, EventTypes, Event
+
+Entity = TypeVar("Entity")
+EntityStatus = TypeVar("EntityStatus", bound=IntEnum)
+EntityFilter = TypeVar("EntityFilter", bound=Filter)
+
+
+class Watch(Generic[Entity, EntityStatus]):
+    """
+    A generic class to track the status and data of an entity.
+
+    Attributes:
+        status_cls (Type[EntityStatus]): The enum class associated to the status of the watched entity.
+        id (str): The unique identifier of the entity.
+        data (Entity): The associated entity data.
+        status_tracker (Dict[str, List[Dict[str, float]]]): A dictionary tracking the timestamps of status changes.
+        current_status (Optional[str]): The current status of the entity.
+    """
+
+    status_cls: Type[EntityStatus]
+
+    def __init__(self, identifier, data=None):
+        """
+        Initializes a Watch instance.
+
+        Args:
+            identifier (str): The unique identifier of the entity.
+            data (Optional[Entity]): The initial data of the entity.
+        """
+        if not hasattr(self, "status_cls"):
+            raise TypeError(f"{self.__class__.__name__} must define 'status_cls'.")
+
+        self.id: str = identifier
+        self._data: Entity = data
+        self.status_tracker: Dict[str, List[Dict[str, Optional[float]]]] = {
+            field.name: [] for field in self.status_cls
+        }
+        self._current_status: str = self.status_cls(self.data.status).name if self.data else None
+
+        if self._current_status:
+            self.status_tracker[self._current_status].append({"start": time.time(), "end": None})
+
+    @property
+    def data(self) -> Entity:
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        self._data = value
+        self.current_status = self.status_cls(value.status).name
+
+    @property
+    def current_status(self) -> str:
+        return self._current_status
+
+    @current_status.setter
+    def current_status(self, value: str):
+        """
+        Updates the status tracker with a new status change.
+
+        Args:
+            new_status (str): The new status to record.
+        """
+        # For the initial refresh we immediately include the current status in the tracker
+        # For subsequent refreshes we only add new ones
+        if self._current_status == value and len(self.status_tracker[value]) != 0:
+            return
+        curr_time = time.time()
+        self._current_status = value
+
+        # Record the new status event.
+        if not self.status_tracker[value]:
+            self.status_tracker[value] = [{"start": curr_time, "end": None}]
+        else:
+            self.status_tracker[value].append({"start": curr_time, "end": None})
+
+        # Mark the end time for any previous statuses.
+        for status, entries in self.status_tracker.items():
+            if status == value:
+                continue
+            if entries and entries[-1]["start"] is not None and entries[-1]["end"] is None:
+                entries[-1]["end"] = curr_time
+
+    def refresh(self, client):
+        """Refreshes the data of the watched entity via a gRPC call. Must be implemented in subclasses."""
+        raise NotImplementedError()
+
+
+class WatchGroup(Generic[EntityFilter]):
+    """
+    A watch group creates multiple watch instances and keeps them updated by listening in to ArmoniK events.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        debug: bool,
+        filter_with: Optional[EntityFilter],
+        session_id: Optional[str],
+        limit: int,
+        entity_ids: Optional[List[str]],
+        sort_by: Optional[Filter],
+        sort_direction: Optional[str],
+    ):
+        """
+        Initializes a WatchGroup instance.
+
+        Args:
+            endpoint (str): The gRPC endpoint.
+            debug (bool): Debug mode toggle.
+            filter_with (Optional[EntityFilter]): The filter criteria.
+            session_id (Optional[str]): The session ID.
+            limit (int): The maximum number of entities to watch.
+            entity_ids (Optional[List[str]]): List of entity IDs.
+            sort_by (Optional[Filter]): Sorting criteria.
+            sort_direction (Optional[str]): Sorting direction.
+        """
+        self.endpoint = endpoint
+        self.filter_with = filter_with
+        self.entity_ids = entity_ids
+        self.limit = limit
+        self.debug = debug
+        self.sort_by = sort_by
+        self.sort_direction = sort_direction
+        self.session_id = session_id
+
+        self.watches: Dict[str, Watch] = {}
+
+        self.grpc_channel = grpc.insecure_channel(self.endpoint)
+
+        self._init_populate_watches()
+
+        if not self.session_id:
+            session_ids = {watch.data.session_id for watch in self.watches.values()}
+
+            if len(session_ids) > 1:
+                raise ValueError(
+                    f"Multiple different session_ids found: {session_ids}, if you're using filters, add a session id constraint (or explicitely set it)."
+                )
+
+            self.session_id = (
+                session_ids.pop()
+                if session_ids
+                else click.prompt(
+                    "We couldn't find any entities that satisfy your filters, enter a session id to automatically watch for and add new entities: "
+                )
+            )
+
+        self._register_event_handlers()
+
+    def _init_populate_watches(self):
+        """Initializes the watches (populate them with data in bulk). Must be implemented in subclasses."""
+        raise NotImplementedError()
+
+    def _register_event_handlers(self):
+        """Registers event handlers. Must be implemented in subclasses."""
+        raise NotImplementedError()
+
+    def get_watches_view(self):
+        """Returns a list of watches in the group."""
+        return list(self.watches.values())
+
+
+class WatchDisplay:
+    """Handles the display of a single watch entity."""
+
+    def __init__(self, watch: Watch, endpoint: Optional[str] = None):
+        """Initializes a WatchDisplay instance."""
+        self.watch = watch
+        self.endpoint = endpoint
+
+    def display(self):
+        """Displays the watch data layout."""
+        display_layout = Layout()
+        display_layout.split_row(self._create_status_display(), self._create_metadata_display())
+        return display_layout
+
+
+class WatchGroupDisplay:
+    """Handles the display of multiple watch entities."""
+
+    def __init__(self, watches: List[Watch], endpoint: Optional[str] = None):
+        self.current_tab = 0
+        self.watches = watches
+        self.endpoint = endpoint
+
+    def update(self):
+        """Handles input for navigation between watch tabs."""
+        key = get_key(blocking=False)
+        if key == "j" or key == "LEFT":
+            self.current_tab = (self.current_tab - 1) % len(self.watches)
+        elif key == "l" or key == "RIGHT":
+            self.current_tab = (self.current_tab + 1) % len(self.watches)
+        elif key == "ESCAPE":
+            raise click.exceptions.Exit(0)
+
+    def update_contents(self, updated_watches):
+        """Updates the watches in the display"""
+        self.watches = updated_watches
+
+    def create_navigation_bar(self):
+        """Create a navigation bar for switching between watches.
+        Returns:
+            Columns: A Rich Columns object representing the navigation tabs.
+        """
+        navigation_tabs = []
+        # TODO: flash navigation tab on update
+        if self.watches:
+            for watch in self.watches:
+                tab = Text(f"{watch.id[:6]}..:{watch.current_status}")
+                if watch.id == self.watches[self.current_tab].id:
+                    tab.stylize(Style(color="black", bgcolor="white", bold=True))
+                else:
+                    tab.stylize("bold magenta")
+                navigation_tabs.append(tab)
+
+        return Columns(navigation_tabs, equal=True, expand=True)
+
+    def create_help_bar(self):
+        return Text("ESC to exit, ←/j to move left, →/l to move right")
+
+    def display(self):
+        raise NotImplementedError()
+
+
+def create_nonblocking_event_handler(
+    channel: grpc.Channel,
+    session_id: str,
+    event_types: List[EventTypes],
+    event_handlers: List[Callable[[str, EventTypes, Event], bool]],
+    task_filter: Optional[TaskFilter] = None,
+    result_filter: Optional[ResultFilter] = None,
+    exception_queue: Optional[
+        Queue
+    ] = None,  # TODO: Capture exceptions from threads and handle them in main
+):
+    """Starts up an event handler in another thread.
+    Args:
+        channel: gRPC channel to create the event clients in
+        session_id: Id of the session whose events we're listening in to
+        event_types: List of events that we're listening to
+        event_handler: List of callback functions for these events
+        task_filter: Optionally whether to filter the tasks whose events we're subscribing to
+        result_filter: Optionally whether to filter the results whose events we're subscribing to
+    Returns:
+        Thread: thread associated to the constructed event handler.
+    """
+
+    def _event_handler():
+        events_client = ArmoniKEvents(channel)
+        events_client.get_events(
+            session_id,
+            event_types,
+            event_handlers,
+            task_filter=task_filter,
+            result_filter=result_filter,
+        )
+
+    event_thread = Thread(target=_event_handler, daemon=True)
+    return event_thread

--- a/src/armonik_cli/core/common.py
+++ b/src/armonik_cli/core/common.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+import time
 import rich_click as click
 
 from typing import Callable, Any
@@ -83,3 +85,32 @@ def global_common_options(command: Callable[..., Any]) -> Callable[..., Any]:
         The decorated command function.
     """
     return apply_click_params(command, output_option, debug_option)
+
+
+def format_timestamp(timestamp):
+    """Format a timestamp as a human-readable string.
+
+    Args:
+        timestamp (Optional[float]): Unix timestamp to format. If None, returns "ongoing".
+
+    Returns:
+        str: Formatted time string in HH:MM:SS format, or "ongoing" if timestamp is None.
+    """
+    if timestamp is None:
+        return "ongoing"
+    return datetime.fromtimestamp(timestamp).strftime("%H:%M:%S")
+
+
+def calculate_duration(start, end):
+    """Calculate the duration between two timestamps.
+
+    Args:
+        start (float): The start time in seconds.
+        end (Optional[float]): The end time in seconds. If None, the current time is used.
+
+    Returns:
+        float: Duration rounded to 2 decimal places.
+    """
+    if end is None:
+        end = time.time()
+    return round(end - start, 2)

--- a/src/armonik_cli/core/input.py
+++ b/src/armonik_cli/core/input.py
@@ -1,0 +1,88 @@
+import sys
+import platform
+import select
+import os
+
+KEY_MAP_UNIX = {
+    "UP": "\x1b[A",
+    "DOWN": "\x1b[B",
+    "RIGHT": "\x1b[C",
+    "LEFT": "\x1b[D",
+    "ESCAPE": "\x1b",
+}
+
+if platform.system() == "Windows":
+    import msvcrt
+
+    def get_key(blocking=True, timeout=0.1, catch_ctrlc=False):
+        """Reads a single key press in Windows."""
+        if not blocking:
+            key = msvcrt.getch() if msvcrt.kbhit() else b""
+        else:
+            try:
+                key1 = msvcrt.getch()
+                # If it's a special character prefix:
+                if key1 in (b"\x00", b"\xe0"):
+                    key2 = msvcrt.getch()
+                    if key2 == b"H":
+                        return "UP"
+                    elif key2 == b"P":
+                        return "DOWN"
+                    elif key2 == b"M":
+                        return "RIGHT"
+                    elif key2 == b"K":
+                        return "LEFT"
+
+                # Otherwise it's a normal key:
+                return key1.decode(errors="ignore")
+            except KeyboardInterrupt:
+                if not catch_ctrlc:
+                    raise
+                key = b"\x03"  # Handle Ctrl+C interruption
+
+        key = key.decode(errors="ignore")  # Decode bytes to string safely
+        return key
+
+else:
+    import tty
+    import termios
+
+    class RawInput:
+        def __enter__(self):
+            self.fd = sys.stdin.fileno()
+            self.old_settings = termios.tcgetattr(self.fd)
+            tty.setcbreak(self.fd)
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            termios.tcsetattr(self.fd, termios.TCSADRAIN, self.old_settings)
+
+    def get_key(blocking=True, timeout=0.1, catch_ctrlc=False):
+        """Reads a single key press from stdin with optional timeout."""
+        with RawInput():
+            ev, _, _ = select.select([sys.stdin], [], [], None if blocking else timeout)
+            if not ev:
+                return ""  # No key within the timeout
+
+            # Read up to, say, 4 bytes
+            # (enough to capture escape + [ + some letter, or smaller sequences)
+            data = os.read(sys.stdin.fileno(), 4).decode(errors="ignore")
+
+            # Now parse what was read:
+            # If it starts with \x1b but has more characters, see if it's an arrow
+            if data.startswith("\x1b"):
+                # Could be an arrow, function key, or just ESC
+                if data.startswith("\x1b[A"):
+                    return "UP"
+                elif data.startswith("\x1b[B"):
+                    return "DOWN"
+                elif data.startswith("\x1b[C"):
+                    return "RIGHT"
+                elif data.startswith("\x1b[D"):
+                    return "LEFT"
+                else:
+                    # The user hit just ESC, or some other escape sequence
+                    return "ESCAPE"
+
+            # For “normal” printable keys, it’ll just be data[0]
+            return data[0]

--- a/tests/commands/test_watch.py
+++ b/tests/commands/test_watch.py
@@ -1,0 +1,543 @@
+from threading import Thread
+import grpc
+import pytest
+from unittest.mock import Mock, patch
+from enum import IntEnum
+from armonik.client import ArmoniKTasks, ArmoniKResults
+from armonik.common import TaskStatus, ResultStatus
+from armonik.client.events import EventTypes
+from armonik_cli.commands.watch import Watch, WatchGroup, create_nonblocking_event_handler
+from armonik_cli.commands.tasks import TaskWatch, TasksWatchGroup
+from armonik_cli.commands.results import ResultWatch, ResultsWatchGroup
+
+
+# Sample Enum for testing
+class SampleStatus(IntEnum):
+    PENDING = 0
+    RUNNING = 1
+    COMPLETED = 2
+
+
+# Sample Entity for testing
+class SampleEntity:
+    def __init__(self, status):
+        self.status = status
+
+
+# Sample Watch subclass
+class SampleWatch(Watch[SampleEntity, SampleStatus]):
+    status_cls = SampleStatus
+
+    def refresh(self, client):
+        pass
+
+
+@pytest.fixture
+def sample_watch():
+    return SampleWatch("entity_1", SampleEntity(SampleStatus.PENDING))
+
+
+# Test Watch class initialization
+def test_watch_initialization(sample_watch):
+    assert sample_watch.id == "entity_1"
+    assert sample_watch.data.status == SampleStatus.PENDING
+    assert sample_watch.current_status == "PENDING"
+    pending_start_time = sample_watch.status_tracker["PENDING"][0]["start"]
+    assert sample_watch.status_tracker == {
+        "PENDING": [{"end": None, "start": pending_start_time}],
+        "RUNNING": [],
+        "COMPLETED": [],
+    }
+
+
+# Test status update
+def test_watch_status_update(sample_watch):
+    sample_watch.current_status = "RUNNING"
+    assert sample_watch.current_status == "RUNNING"
+    assert "start" in sample_watch.status_tracker["RUNNING"][-1]
+
+
+# Test WatchGroup class
+def test_watch_group_initialization():
+    with patch("grpc.insecure_channel"):
+        with pytest.raises(NotImplementedError):
+            WatchGroup("localhost", False, None, None, 10, None, None, None)
+
+
+# Test create_nonblocking_event_handler
+def test_create_nonblocking_event_handler():
+    channel = Mock()
+    session_id = "test_session"
+    event_types = [EventTypes.NEW_TASK]
+    event_handlers = [lambda s, e, ev: True]
+
+    event_thread = create_nonblocking_event_handler(
+        channel, session_id, event_types, event_handlers
+    )
+
+    assert isinstance(event_thread, Thread)
+    assert event_thread.daemon
+
+
+# Tests for the non generic watch objects
+
+
+class StubChannel(grpc.Channel):
+    def unary_unary(self, *args, **kwargs):
+        """Simulate a unary-unary RPC. Return a callable that does nothing."""
+
+        def fake_rpc(request, timeout=None, metadata=None, credentials=None):
+            return None
+
+        return fake_rpc
+
+    def stream_unary(self, *args, **kwargs):
+        """Simulate a stream-unary RPC."""
+
+        def fake_stream(requests, timeout=None, metadata=None, credentials=None):
+            return None
+
+        return fake_stream
+
+    def unary_stream(self, *args, **kwargs):
+        """Simulate a stream-unary RPC."""
+
+        def fake_unary_stream(request, timeout=None, metadata=None, credentials=None):
+            yield from []
+
+        return fake_unary_stream
+
+    def stream_stream(self, *args, **kwargs):
+        """Simulate a stream-stream RPC."""
+
+        def fake_stream_stream(requests, timeout=None, metadata=None, credentials=None):
+            yield from []
+
+        return fake_stream_stream
+
+    def subscribe(self, callback, try_to_connect=False):
+        """Subscribe to connectivity changes. No-op."""
+        pass
+
+    def unsubscribe(self, callback):
+        """Unsubscribe from connectivity changes. No-op."""
+        pass
+
+    def close(self):
+        """Close the channel. No-op."""
+        pass
+
+
+@pytest.fixture
+def patch_grpc_channel(monkeypatch):
+    def fake_insecure_channel(endpoint):
+        return StubChannel()
+
+    monkeypatch.setattr("grpc.insecure_channel", fake_insecure_channel)
+
+
+class StubArmoniKEvents:
+    def __init__(self, channel):
+        self.channel = channel
+
+    def get_events(
+        self, session_id, event_types, event_handlers, task_filter=None, result_filter=None
+    ):
+        pass
+
+
+@pytest.fixture
+def patch_armonik_clients(monkeypatch):
+    monkeypatch.setattr("armonik.client.events.ArmoniKEvents", StubArmoniKEvents)
+
+
+class StubTask:
+    """
+    Minimal stub simulating the relevant parts of a Task.
+    """
+
+    def __init__(self, status, session_id="some_session_id"):
+        self.status = status  # e.g., an int from TaskStatus
+        self.session_id = session_id
+
+    def refresh(self, client):
+        """
+        Pretend to do some network call, but actually just updates self.status
+        for testing. We'll do something trivial here.
+        """
+        if self.status == TaskStatus.CREATING:
+            self.status = TaskStatus.PROCESSING
+        elif self.status == TaskStatus.PROCESSING:
+            self.status = TaskStatus.COMPLETED
+
+
+class StubResult:
+    """
+    Minimal stub for a real 'Result' object,
+    with a .refresh(...) method.
+    """
+
+    def __init__(self, result_id, status, session_id="dummy_sess"):
+        self.result_id = result_id
+        self.status = status
+        self.session_id = session_id
+
+    def refresh(self, client):
+        """
+        Fake a status transition if you want, or do nothing.
+        """
+        if self.status == ResultStatus.CREATED:
+            self.status = ResultStatus.COMPLETED
+
+
+class StubArmoniKResults:
+    def __init__(self, channel):
+        self.channel = channel
+
+    def list_results(self, result_filter, page, page_size, sort_field, sort_direction):
+        # Return count + list of results
+        return (
+            2,
+            [
+                StubResult("resultA", ResultStatus.CREATED, "sessXYZ"),
+                StubResult("resultB", ResultStatus.COMPLETED, "sessXYZ"),
+            ],
+        )
+
+    def get_result(self, result_id):
+        return StubResult(result_id, ResultStatus.COMPLETED, "sessXYZ")
+
+
+@pytest.fixture
+def patch_armonik_results_init(monkeypatch):
+    """Prevent the real ArmoniKResults from doing gRPC."""
+
+    def fake_init(self, channel):
+        # do not set up real stubs
+        self.channel = channel
+        self._client = None
+
+    monkeypatch.setattr(ArmoniKResults, "__init__", fake_init)
+
+
+@pytest.fixture
+def patch_armonik_results_list(monkeypatch):
+    """Patch list_results so no real network call is made."""
+
+    def fake_list_results(self, result_filter, page, page_size, sort_field, sort_direction):
+        return StubArmoniKResults(None).list_results(
+            result_filter, page, page_size, sort_field, sort_direction
+        )
+
+    monkeypatch.setattr(ArmoniKResults, "list_results", fake_list_results)
+
+
+@pytest.fixture
+def patch_armonik_results_get(monkeypatch):
+    """Patch get_result for the refresh calls."""
+
+    def fake_get_result(self, result_id):
+        return StubArmoniKResults(None).get_result(result_id)
+
+    monkeypatch.setattr(ArmoniKResults, "get_result", fake_get_result)
+
+
+@pytest.fixture
+def patch_armonik_tasks_init(monkeypatch):
+    """Prevents ArmoniKTasks from creating a real gRPC client."""
+
+    def fake_init(self, channel):
+        # Do not create or assign a real self._client
+        self._client = None
+        self.channel = channel
+
+    monkeypatch.setattr(ArmoniKTasks, "__init__", fake_init)
+
+
+@pytest.fixture
+def patch_armonik_tasks_list(monkeypatch):
+    """Stubs out list_tasks(...) so it doesn't do a real RPC."""
+
+    def fake_list_tasks(self, task_filter, page, page_size, sort_field, sort_direction):
+        class FakeTask:
+            def __init__(self, id_, status_, session_id):
+                self.id = id_
+                self.status = status_
+                self.session_id = session_id
+
+        return (2, [FakeTask("taskA", 0, "s123"), FakeTask("taskB", 1, "s123")])
+
+    monkeypatch.setattr(ArmoniKTasks, "list_tasks", fake_list_tasks)
+
+
+@pytest.fixture
+def patch_event_handler(monkeypatch):
+    def fake_event_handler(*args, **kwargs):
+        class FakeThread:
+            def start(self_):
+                pass  # do nothing
+
+        return FakeThread()
+
+    # Replace the real function
+    monkeypatch.setattr(
+        "armonik_cli.commands.watch.create_nonblocking_event_handler", fake_event_handler
+    )
+
+
+@pytest.fixture
+def stub_task():
+    # Start in CREATING status
+    return StubTask(status=TaskStatus.CREATING)
+
+
+def test_task_watch_initialization(stub_task):
+    watch = TaskWatch(identifier="task123", data=stub_task)
+    assert watch.id == "task123"
+    assert watch.current_status == "CREATING"  # from TaskStatus.CREATING
+
+
+def test_task_watch_status_tracker(stub_task):
+    watch = TaskWatch(identifier="task123", data=stub_task)
+    # Initially, CREATING status gets recorded
+    assert watch.status_tracker["CREATING"]
+    assert len(watch.status_tracker["CREATING"]) == 1
+
+    # Simulate changing the underlying task status
+    stub_task.status = TaskStatus.PROCESSING
+    # Assign watch.data to trigger the setter and status update
+    watch.data = stub_task
+
+    assert watch.current_status == "PROCESSING"
+    # CREATING has an end time
+    assert watch.status_tracker["CREATING"][0]["end"] is not None
+    # PROCESSING has a new entry
+    assert len(watch.status_tracker["PROCESSING"]) == 1
+    assert watch.status_tracker["PROCESSING"][0]["end"] is None
+
+
+def test_task_watch_refresh(stub_task):
+    watch = TaskWatch(identifier="task123", data=stub_task)
+
+    class StubClient:
+        pass
+
+    client = StubClient()
+    watch.refresh(client)
+
+    # After refresh, we expect the stub task to go from CREATING to PROCESSING
+    assert watch.current_status == "PROCESSING"
+    # Check the status_tracker for the new transition
+    assert watch.status_tracker["CREATING"][0]["end"] is not None
+    assert len(watch.status_tracker["PROCESSING"]) == 1
+
+
+def test_tasks_watch_group_init_with_ids(
+    mocker,
+    patch_armonik_clients,
+    patch_event_handler,
+    patch_armonik_tasks_init,
+    patch_armonik_tasks_list,
+):
+    """
+    If 'entity_ids' are given, the group shouldn't call list_tasks;
+    it should create watchers directly.
+    """
+
+    mocker.patch.object(TaskWatch, "refresh", side_effect=lambda client: None)
+    group = TasksWatchGroup(
+        endpoint="fake_endpoint",
+        debug=False,
+        filter_with=None,
+        session_id="sessXYZ",
+        limit=2,
+        entity_ids=["taskX", "taskY"],
+        sort_by=None,
+        sort_direction="asc",
+    )
+
+    assert len(group.watches) == 2
+    assert isinstance(group.watches["taskX"], TaskWatch)
+    assert isinstance(group.watches["taskY"], TaskWatch)
+
+
+def test_tasks_watch_group_init_no_ids(
+    mocker,
+    patch_armonik_tasks_init,
+    patch_armonik_tasks_list,
+    patch_armonik_clients,
+    patch_event_handler,
+):
+    """
+    If no entity_ids are provided, ensure the group calls list_tasks.
+    """
+    mocker.patch.object(TaskWatch, "refresh", side_effect=lambda client: None)
+
+    group = TasksWatchGroup(
+        endpoint="fake_endpoint",
+        debug=False,
+        filter_with=None,
+        session_id=None,
+        limit=2,
+        entity_ids=None,
+        sort_by=None,
+        sort_direction="asc",
+    )
+
+    # The stub returns tasks with session_id="s123", so we check that
+    assert len(group.watches) == 2
+    assert "taskA" in group.watches
+    assert "taskB" in group.watches
+    # The group should derive session_id from the tasks
+    assert group.session_id == "s123"
+
+
+def test_tasks_watch_group_event_callbacks(
+    mocker,
+    patch_armonik_clients,
+    patch_event_handler,
+    patch_armonik_tasks_init,
+    patch_armonik_tasks_list,
+):
+    """
+    Test that event callbacks (update_watch_status, etc.) update watchers.
+    """
+    mocker.patch.object(TaskWatch, "refresh", side_effect=lambda client: None)
+
+    group = TasksWatchGroup(
+        endpoint="fake_endpoint",
+        debug=False,
+        filter_with=None,
+        session_id="my_session",
+        limit=2,
+        entity_ids=["taskZ"],
+        sort_by=None,
+        sort_direction="asc",
+    )
+    # By default, it will create watchers for [taskZ], and refresh them.
+
+    # Add a watch manually for demonstration:
+    group.watches["taskZ"].current_status = "CREATING"
+
+    # Simulate an event object
+    class StubEvent:
+        task_id = "taskZ"
+        status = TaskStatus.COMPLETED
+
+    # Fire the update callback
+    group.update_watch_status("my_session", EventTypes.TASK_STATUS_UPDATE, StubEvent())
+    # Check if the watch was updated
+    assert group.watches["taskZ"].current_status == "COMPLETED"
+
+
+def test_result_watch_init():
+    # Start with a stub result in CREATED
+    stub = StubResult("result123", ResultStatus.CREATED, "sessID")
+    watch = ResultWatch(identifier="result123", data=stub)
+    assert watch.id == "result123"
+    assert watch.current_status == "CREATED"
+    assert watch.data == stub
+    # Check initial tracking
+    assert len(watch.status_tracker["CREATED"]) == 1
+
+
+def test_result_watch_refresh():
+    stub = StubResult("rX", ResultStatus.CREATED)
+    watch = ResultWatch("rX", data=stub)
+
+    # Provide a client stub
+    class StubClient:
+        def get_result(self, rid):
+            # Always return a COMPLETED result
+            return StubResult(rid, ResultStatus.COMPLETED, "sessID")
+
+    watch.refresh(StubClient())
+    # Should now be COMPLETED
+    assert watch.current_status == "COMPLETED"
+    assert len(watch.status_tracker["COMPLETED"]) == 1
+    # "CREATED" entry should have an end time
+    assert watch.status_tracker["CREATED"][0]["end"] is not None
+
+
+def test_results_watch_group_init_with_ids(
+    patch_armonik_results_init,
+    patch_armonik_results_list,
+    patch_armonik_results_get,
+    patch_event_handler,
+    patch_grpc_channel,
+):
+    """
+    If 'entity_ids' are given, we do not call list_results;
+    watchers are created directly and refresh is called.
+    """
+    group = ResultsWatchGroup(
+        endpoint="fake_endpoint",
+        debug=False,
+        filter_with=None,
+        session_id="sessionXYZ",
+        limit=2,
+        entity_ids=["r1", "r2"],
+        sort_by=None,
+        sort_direction="asc",
+    )
+    assert len(group.watches) == 2
+    assert "r1" in group.watches
+    assert "r2" in group.watches
+
+
+def test_results_watch_group_init_no_ids(
+    patch_armonik_results_init,
+    patch_armonik_results_list,
+    patch_armonik_results_get,
+    patch_event_handler,
+    patch_grpc_channel,
+):
+    """
+    If no entity_ids => we call list_results => returns 2 stubs from our monkeypatch.
+    """
+    group = ResultsWatchGroup(
+        endpoint="fake_endpoint",
+        debug=False,
+        filter_with=None,
+        session_id=None,
+        limit=2,
+        entity_ids=None,
+        sort_by=None,
+        sort_direction="asc",
+    )
+    # Stub returns 2 results: (resultA, resultB) with session_id="sessXYZ"
+    assert len(group.watches) == 2
+    assert "resultA" in group.watches
+    assert "resultB" in group.watches
+    assert group.session_id == "sessXYZ"
+
+
+def test_results_watch_group_event_callback(
+    patch_armonik_results_init,
+    patch_armonik_results_list,
+    patch_armonik_results_get,
+    patch_event_handler,
+    patch_grpc_channel,
+):
+    """
+    Test that 'update_watch_status' changes watchers for RESULT_STATUS_UPDATE events.
+    """
+    group = ResultsWatchGroup(
+        endpoint="fake_endpoint",
+        debug=False,
+        filter_with=None,
+        session_id="some_sess",
+        limit=2,
+        entity_ids=["resZ"],
+        sort_by=None,
+        sort_direction="asc",
+    )
+    # By default, watch "resZ"
+    group.watches["resZ"].current_status = "CREATED"
+
+    class StubEvent:
+        result_id = "resZ"
+        status = ResultStatus.COMPLETED
+
+    group.update_watch_status("some_sess", EventTypes.RESULT_STATUS_UPDATE, StubEvent())
+    assert group.watches["resZ"].current_status == "COMPLETED"

--- a/tests/core/test_input.py
+++ b/tests/core/test_input.py
@@ -1,0 +1,83 @@
+import pytest
+import sys
+import platform
+from unittest.mock import patch
+
+if platform.system() == "Windows":
+    from armonik_cli.core.input import get_key  # Replace `your_module` with the actual module name
+else:
+    from armonik_cli.core.input import (
+        get_key,
+    )  # Replace `your_module` with the actual module name
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific tests")
+def test_get_key_windows_blocking():
+    """Test `get_key` on Windows in blocking mode"""
+    with patch("msvcrt.getch", return_value=b"A"):
+        key = get_key(blocking=True)
+        assert key == "A"
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific tests")
+def test_get_key_windows_nonblocking():
+    """Test `get_key` on Windows in non-blocking mode"""
+    with patch("msvcrt.kbhit", return_value=True), patch("msvcrt.getch", return_value=b"B"):
+        key = get_key(blocking=False)
+        assert key == "B"
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific tests")
+def test_get_key_windows_nonblocking_no_key():
+    """Test `get_key` on Windows in non-blocking mode when no key is pressed"""
+    with patch("msvcrt.kbhit", return_value=False):
+        key = get_key(blocking=False)
+        assert key == ""  # No key was pressed
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific tests")
+def test_get_key_unix_blocking():
+    """Test `get_key` on Unix in blocking mode"""
+    with patch("os.read", return_value=b"C"), patch("sys.stdin.fileno", return_value=0), patch(
+        "termios.tcgetattr"
+    ), patch("tty.setcbreak"), patch("termios.tcsetattr"):
+        key = get_key(blocking=True)
+        assert key == "C"
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific tests")
+def test_get_key_unix_nonblocking_key_pressed():
+    """Test `get_key` on Unix in non-blocking mode when a key is pressed"""
+    with patch("select.select", return_value=([sys.stdin], [], [])), patch(
+        "os.read", return_value=b"D"
+    ), patch("sys.stdin.fileno", return_value=0), patch("termios.tcgetattr"), patch(
+        "tty.setcbreak"
+    ), patch("termios.tcsetattr"):
+        key = get_key(blocking=False)
+        assert key == "D"
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix-specific tests")
+def test_get_key_unix_nonblocking_no_key():
+    """Test `get_key` on Unix in non-blocking mode when no key is pressed"""
+    with patch("select.select", return_value=([], [], [])), patch(
+        "sys.stdin.fileno", return_value=0
+    ), patch("termios.tcgetattr"), patch("tty.setcbreak"), patch("termios.tcsetattr"):
+        key = get_key(blocking=False)
+        assert key == ""  # No key was pressed
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific tests")
+def test_get_key_windows_ctrl_c():
+    """Test `get_key` on Windows catching Ctrl+C"""
+    with patch("msvcrt.getch", side_effect=KeyboardInterrupt):
+        key = get_key(blocking=True, catch=True)
+        assert key == "\x03"  # Ctrl+C
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows-specific tests")
+def test_get_key_windows_keyboard_interrupt():
+    """Test `get_key` on Windows raising KeyboardInterrupt"""
+    with patch("msvcrt.getch", side_effect=KeyboardInterrupt):
+        with pytest.raises(KeyboardInterrupt):
+            get_key(blocking=True, catch=False)


### PR DESCRIPTION
# Motivation

The ArmoniK CLI provided a functionality to get tasks/results, but no actual way of efficiently observing said tasks/results. This PR introduces two new commands that provide this functionality in a visually appealing way whilst also being conservative in terms of its performance impact (Making use of the already existing events system instead of polling).

# Description

- Added input handling to core
- Added reusable objects to track the state of certain ArmoniK entities
- Added task watch command 
![image](https://github.com/user-attachments/assets/569a0a24-66c7-4bdc-bc94-6cf49cf9e10e)
- Added results watch command 
![image](https://github.com/user-attachments/assets/fe0a6bd3-fe66-4f0c-baf9-d29a258698a7)


# Testing

Wrote unite tests that cover the new features (with the exception of the objects created to display the information because it just wouldn't be easy to unit test visuals)

# Impact

No direct impact on ArmoniK.

# Additional Information

I did notice some points of improvements which I left as `# TODO` comments in the code

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
