### PR TITLE
fix: Hook generating the project version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,10 +25,10 @@ def get_local_schema(version: ScmVersion) -> str:
         The custom local version string.
     """
     run_id = environ.get("GITHUB_RUN_ID", "0")
-    release = environ.get("RELEASE", "")
-    if not release:
-        return f".dev{run_id}"
-    return ""
+    event_name = environ.get("GITHUB_EVENT_NAME", "")
+    if event_name == "release":
+        return ""
+    return f".dev{run_id}"
 
 
 setup(


### PR DESCRIPTION
# Motivation

The version number generated for a release contains the string '“.dev<run-id>”.

# Description

Correct the version number generation script.

# Testing

Not applicable.

# Impact

Not applicable.

# Additional Information

Not applicable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
