### PR TITLE
fix: API doc generation missing and TLS condition

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,6 +14,15 @@ help:
 
 .PHONY: help Makefile
 
+apidoc:
+	@mkdir -p api
+	@find api -type f -name "*.rst" ! -name "index.rst" ! -name "modules.rst" -exec rm -f {} \;
+	sphinx-apidoc -f -o api ../src/armonik_cli ../src/armonik_cli/commands
+	@echo "Auto-generated API documentation."
+
+html: apidoc
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/docs/api/armonik_cli.core.rst
+++ b/docs/api/armonik_cli.core.rst
@@ -1,0 +1,85 @@
+armonik\_cli.core package
+=========================
+
+Submodules
+----------
+
+armonik\_cli.core.common module
+-------------------------------
+
+.. automodule:: armonik_cli.core.common
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.core.configuration module
+--------------------------------------
+
+.. automodule:: armonik_cli.core.configuration
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.core.console module
+--------------------------------
+
+.. automodule:: armonik_cli.core.console
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.core.decorators module
+-----------------------------------
+
+.. automodule:: armonik_cli.core.decorators
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.core.filters module
+--------------------------------
+
+.. automodule:: armonik_cli.core.filters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.core.logging module
+--------------------------------
+
+.. automodule:: armonik_cli.core.logging
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.core.options module
+--------------------------------
+
+.. automodule:: armonik_cli.core.options
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.core.params module
+-------------------------------
+
+.. automodule:: armonik_cli.core.params
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.core.serialize module
+----------------------------------
+
+.. automodule:: armonik_cli.core.serialize
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: armonik_cli.core
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/armonik_cli.rst
+++ b/docs/api/armonik_cli.rst
@@ -1,0 +1,45 @@
+armonik\_cli package
+====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   armonik_cli.core
+
+Submodules
+----------
+
+armonik\_cli.cli module
+-----------------------
+
+.. automodule:: armonik_cli.cli
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.exceptions module
+------------------------------
+
+.. automodule:: armonik_cli.exceptions
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+armonik\_cli.utils module
+-------------------------
+
+.. automodule:: armonik_cli.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: armonik_cli
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,8 @@
+API Reference
+============
+
+.. toctree::
+   :maxdepth: 2
+   :caption: ArmoniK CLI API Reference
+
+   modules

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,7 @@
+armonik_cli
+===========
+
+.. toctree::
+   :maxdepth: 4
+
+   armonik_cli

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ author = "Quentin Delamea"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
     "sphinx_click",
 ]
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,3 +17,4 @@ This repository is part of the `ArmoniK <https://github.com/aneoconsulting/Armon
 
    development
    armonik_core
+   api/index

--- a/src/armonik_cli/core/configuration.py
+++ b/src/armonik_cli/core/configuration.py
@@ -354,7 +354,7 @@ def create_grpc_channel(config: CliConfig) -> grpc.Channel:
         cleaner_endpoint = cleaner_endpoint[7:]
     if cleaner_endpoint.endswith("/"):
         cleaner_endpoint = cleaner_endpoint[:-1]
-    if config.certificate_authority and config.client_certificate and config.client_key:
+    if config.certificate_authority:
         # Create grpc channel with tls
         channel = create_channel(
             cleaner_endpoint,


### PR DESCRIPTION
# Motivation

Not applicable.

# Description

- Added missing API docs generation to the Makefile
- removed superfluous conditions for `create_grpc_channel`.

# Testing

All previous tests pass.

# Impact

Not applicable.

# Additional Information

Not applicable. 

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
