### PR TITLE
fix: Fixed publish pipeline failing at armonik-cli-core

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -34,7 +34,3 @@ jobs:
       - name: Publish armonik-cli to PyPi
         if: github.event_name == 'release' # Publish on releases
         run: uv publish -t ${{ secrets.PYPI_CLI_TOKEN }} 
-
-      - name: Publish armonik-cli-core to PyPi
-        if: github.event_name == 'release' # Publish on releases
-        run: uv publish --package armonik_cli_core -t ${{ secrets.PYPI_CLI_TOKEN }} 


### PR DESCRIPTION
# Motivation

Publish pipeline failed even though the packages were published. 

# Description

uv publishes all the packages of a workspace, you don't need to publish them separately, so I removed the last step for the armonik-cli-core.

# Testing

Not applicable.

# Impact

Not applicable.

# Additional Information

None.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
