### PR TITLE
feat: session creation defaults

### DIFF
--- a/src/armonik_cli/commands/sessions.py
+++ b/src/armonik_cli/commands/sessions.py
@@ -107,20 +107,18 @@ def session_get(config: CliConfig, session_ids: List[str], **kwargs) -> Optional
 @click.option(
     "--max-retries",
     type=int,
-    required=True,
+    default=3,
     help="Maximum default number of execution attempts for session tasks.",
     metavar="NUM_RETRIES",
 )
 @click.option(
     "--max-duration",
     type=TimeDeltaParam(),
-    required=True,
+    default="00:01:00.00",
     help="Maximum default task execution time (format HH:MM:SS.MS).",
     metavar="DURATION",
 )
-@click.option(
-    "--priority", type=int, required=True, help="Default task priority.", metavar="PRIORITY"
-)
+@click.option("--priority", type=int, default=1, help="Default task priority.", metavar="PRIORITY")
 @click.option(
     "--partition",
     type=str,


### PR DESCRIPTION
# Motivation

You need to pass in certain task options when creating sessions, I think we can just use reasonable defaults and leave it to the user to specify if needed. This closes #84 

# Description

Added default values for task options

# Testing

Not Applicable.

# Impact

Not applicable.

# Additional Information

This goes against the API's behavior, but this is "to be discussed"

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
